### PR TITLE
Add composer project file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore development files with "export-ignore".
+/.editorconfig      export-ignore
+/.github            export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/watch.sh           export-ignore

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "cu-communityapps/cwd-framework-lite",
+    "name": "cubear/cwd-framework-lite",
     "license": "MIT",
     "type": "library"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "name": "cu-communityapps/cwd-framework-lite",
+    "license": "MIT",
+    "type": "library"
+}


### PR DESCRIPTION
Adding composer.json to support retrieving the assets from this repo as a composer dependency.

I was able to use composer to add this to the [Laravel Starter Kit installation](https://github.com/CU-CommunityApps/CD-LaravelStarterKit/pull/31).

With this PR, this project could be added to Packagist. The composer.json file may need some adjustments to be done right for that. And it needs to be a public repo.